### PR TITLE
Use shared classes for project accents and flags

### DIFF
--- a/En/Projects/coloria.html
+++ b/En/Projects/coloria.html
@@ -35,7 +35,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../../Fr/Projects/coloria.html" title="Passer à la version française">
-                        <img src="../../assets/flag_fr.png" alt="Français" style="width:24px; height:auto;">
+                        <img src="../../assets/flag_fr.png" alt="Français" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/En/Projects/facial_recognition.html
+++ b/En/Projects/facial_recognition.html
@@ -35,7 +35,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../../Fr/Projects/reconnaissance-faciale.html" title="Passer à la version française">
-                        <img src="../../assets/flag_fr.png" alt="Français" style="width:24px; height:auto;">
+                        <img src="../../assets/flag_fr.png" alt="Français" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/En/contact.html
+++ b/En/contact.html
@@ -37,7 +37,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../Fr/contact.html" title="Passer à la version française">
-                        <img src="../assets/flag_fr.png" alt="Français" style="width:24px; height:auto;">
+                        <img src="../assets/flag_fr.png" alt="Français" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/En/index.html
+++ b/En/index.html
@@ -35,7 +35,7 @@
                 <li><a href="contact.html">Contact</a></li>
                 <li>
                     <a href="../Fr/index.html" title="Switch to French version">
-                        <img src="../assets/flag_fr.png" alt="Français" style="width:24px; height:auto;">
+                        <img src="../assets/flag_fr.png" alt="Français" class="language-flag">
                     </a>
                 </li>
             </ul>
@@ -55,7 +55,7 @@
             </section>
 
             <section id="journey">
-                <h2 style="margin-top: 50px;">My Journey: From Curiosity to Passion</h2>
+                <h2 class="section-heading">My Journey: From Curiosity to Passion</h2>
                 <p>
                     Growing up in Véretz, a small town in Touraine, I developed two major passions: combat sports, which taught me discipline and resilience, and a fascination for how things work. I loved taking apart everyday objects just to understand their mechanisms. This curiosity naturally led me to discover electronics and, later, computer science.
                 </p>
@@ -68,14 +68,14 @@
             </section>
 
             <section id="esiee">
-                <h2 style="margin-top: 50px;">ESIEE Paris: A Key Milestone</h2>
+                <h2 class="section-heading">ESIEE Paris: A Key Milestone</h2>
                 <p>
                     Joining ESIEE Paris in 2019 was a game-changer. I moved to Paris with a clear goal: to study at a top school where I could dive into artificial intelligence and cybersecurity. This journey has not only sharpened my technical skills but also broadened my understanding of the professional world.
                 </p>
             </section>
 
             <section id="experiences">
-                <h2 style="margin-top: 50px;">Key Experiences and Projects</h2>
+                <h2 class="section-heading">Key Experiences and Projects</h2>
 
                 <h3>Chez BOB</h3>
                 <p>
@@ -99,21 +99,21 @@
             </section>
 
             <section id="future">
-                <h2 style="margin-top: 50px;">Looking Ahead</h2>
+                <h2 class="section-heading">Looking Ahead</h2>
                 <p>
                     One of my biggest passions is the automotive industry. I dream of contributing to innovative AI and cybersecurity solutions for this field. My goal is to merge my technical skills with an industry that's constantly evolving and shaping the future.
                 </p>
             </section>
 
             <section id="hobbies">
-                <h2 style="margin-top: 50px;">Hobbies and Interests</h2>
+                <h2 class="section-heading">Hobbies and Interests</h2>
                 <p>
                     Outside of work, I enjoy music, science, cooking, pastry-making, and, of course, combat sports. These hobbies keep me balanced and spark my creativity.
                 </p>
             </section>
 
             <section id="skills">
-                <h2 style="margin-top: 50px;">Key Skills</h2>
+                <h2 class="section-heading">Key Skills</h2>
                 <ul>
                     <li><strong>Programming Languages:</strong> Python, JavaScript, C</li>
                     <li><strong>Technologies:</strong> Artificial Intelligence, Cybersecurity, Web Development</li>

--- a/En/projects.html
+++ b/En/projects.html
@@ -38,7 +38,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../Fr/projects.html" title="Passer à la version française">
-                        <img src="../assets/flag_fr.png" alt="Français" style="width:24px; height:auto;">
+                        <img src="../assets/flag_fr.png" alt="Français" class="language-flag">
                     </a>
                 </li>
             </ul>
@@ -54,11 +54,11 @@
                 <h2>Projects</h2>
                 <div class="grid">
                     <a href="Projects/coloria.html" class="project">
-                        <h3 style="color: #1e90ff;">COLORIA -2023 (Final 3rd Year Project)</h3>
+                        <h3 class="project-title-accent">COLORIA -2023 (Final 3rd Year Project)</h3>
                         <p>An AI-powered web solution for image colorization to bring black and white photos back to life.</p>
                     </a>
                     <a href="Projects/facial_recognition.html" class="project">
-                        <h3 style="color: #1e90ff;">Facial Recognition -2023</h3>
+                        <h3 class="project-title-accent">Facial Recognition -2023</h3>
                         <p>An AI project capable of identifying faces in real-time.</p>
                     </a>
                 </div>

--- a/Fr/Experiences/Chez-BOB.html
+++ b/Fr/Experiences/Chez-BOB.html
@@ -16,7 +16,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../En/Experiences/Chez-Bob.html" title="Passer à la version anglaise">
-                        <img src="../assets/flag_en.png" alt="English" style="width:24px; height:auto;">
+                        <img src="../assets/flag_en.png" alt="English" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/Fr/Experiences/La-Campagnarde.htm
+++ b/Fr/Experiences/La-Campagnarde.htm
@@ -16,7 +16,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../En/Experiences/La-Campagnarde.html" title="Passer à la version anglaise">
-                        <img src="../assets/flag_en.png" alt="English" style="width:24px; height:auto;">
+                        <img src="../assets/flag_en.png" alt="English" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/Fr/Projects/coloria.html
+++ b/Fr/Projects/coloria.html
@@ -35,7 +35,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../../En/Projects/coloria.html" title="Passer à la version anglaise">
-                        <img src="../../assets/flag_en.png" alt="English" style="width:24px; height:auto;">
+                        <img src="../../assets/flag_en.png" alt="English" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/Fr/Projects/reconnaissance-faciale.html
+++ b/Fr/Projects/reconnaissance-faciale.html
@@ -35,7 +35,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../../En/Projects/facial_recognition.html" title="Passer à la version anglaise">
-                        <img src="../../assets/flag_en.png" alt="English" style="width:24px; height:auto;">
+                        <img src="../../assets/flag_en.png" alt="English" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/Fr/contact.html
+++ b/Fr/contact.html
@@ -37,7 +37,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../En/contact.html" title="Passer à la version anglaise">
-                        <img src="../assets/flag_en.png" alt="English" style="width:24px; height:auto;">
+                        <img src="../assets/flag_en.png" alt="English" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/Fr/index.html
+++ b/Fr/index.html
@@ -36,7 +36,7 @@
                 <li><a href="contact.html">Contact</a></li>
                 <li>
                     <a href="../En/index.html" title="Passer à la version anglaise">
-                        <img src="../assets/flag_en.png" alt="English" style="width:24px; height:auto;">
+                        <img src="../assets/flag_en.png" alt="English" class="language-flag">
                     </a>
                 </li>
             </ul>

--- a/Fr/projects.html
+++ b/Fr/projects.html
@@ -38,7 +38,7 @@
                 <!-- Language switch button -->
                 <li>
                     <a href="../En/projects.html" title="Passer à la version anglaise">
-                        <img src="../assets/flag_en.png" alt="English" style="width:24px; height:auto;">
+                        <img src="../assets/flag_en.png" alt="English" class="language-flag">
                     </a>
                 </li>
             </ul>
@@ -54,11 +54,11 @@
                 <h2>Projets</h2>
                 <div class="grid">
                     <a href="Projects/coloria.html" class="project">
-                        <h3 style="color: #1e90ff;">COLORIA -2023 (Projet de fin de 3e année)</h3>
+                        <h3 class="project-title-accent">COLORIA -2023 (Projet de fin de 3e année)</h3>
                         <p>Une solution web d'IA de colorisation d'image pour redonner vie aux photos en noir et blanc.</p>
                     </a>
                     <a href="Projects/reconnaissance-faciale.html" class="project">
-                        <h3 style="color: #1e90ff;">Reconnaissance faciale -2023</h3>
+                        <h3 class="project-title-accent">Reconnaissance faciale -2023</h3>
                         <p>Un projet d'IA capable d'identifier des visages en temps réel.</p>
                     </a>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,19 @@ a:hover {
     text-decoration: none; /* Toujours sans soulignement */
 }
 
+.project-title-accent {
+    color: #1e90ff;
+}
+
+.language-flag {
+    width: 24px;
+    height: auto;
+}
+
+.section-heading {
+    margin-top: 50px;
+}
+
 /* Main */
 .container {
     width: 90%;


### PR DESCRIPTION
## Summary
- add reusable styles for project title accents, language switcher flags, and heading spacing
- replace inline colour and sizing on the French and English project listings with the new CSS class
- clean up remaining inline styles by adopting classes on navigation flags and section headings

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c85590cfa883288f876769a427d99d