### PR TITLE
Add thumbnails and styling to project detail cards

### DIFF
--- a/En/Projects/coloria.html
+++ b/En/Projects/coloria.html
@@ -43,6 +43,7 @@
     </header>
 
     <main>
+        <img class="project-thumb" src="../../assets/coloria-thumb.svg" alt="Illustration of the COLORIA project bringing color back to black and white photos">
         <h1 class="project-title">COLORIA</h1>
         <a class="git-link" href="https://github.com/hugo-kte/COLORIA">Voir le projet sur GitHub</a>
         <section id="pdf-viewer" class="pdf-viewer">

--- a/En/Projects/facial_recognition.html
+++ b/En/Projects/facial_recognition.html
@@ -43,6 +43,7 @@
     </header>
 
     <main>
+        <img class="project-thumb" src="../../assets/facial-recognition-thumb.svg" alt="Illustration of the facial recognition project with a digital face scan">
         <h1 class="project-title">Reconnaissance Faciale</h1>
         <a class="git-link" href="https://github.com/hugo-kte/reconaissance-faciale">Voir le projet sur GitHub</a>
         <section id="pdf-viewer" class="pdf-viewer">

--- a/Fr/Projects/coloria.html
+++ b/Fr/Projects/coloria.html
@@ -43,6 +43,7 @@
     </header>
 
     <main>
+        <img class="project-thumb" src="../../assets/coloria-thumb.svg" alt="Illustration du projet COLORIA redonnant des couleurs aux photos en noir et blanc">
         <h1 class="project-title">COLORIA</h1>
         <a class="git-link" href="https://github.com/hugo-kte/COLORIA">Voir le projet sur GitHub</a>
         <section id="pdf-viewer" class="pdf-viewer">

--- a/Fr/Projects/reconnaissance-faciale.html
+++ b/Fr/Projects/reconnaissance-faciale.html
@@ -43,6 +43,7 @@
     </header>
 
     <main>
+        <img class="project-thumb" src="../../assets/facial-recognition-thumb.svg" alt="Illustration du projet de reconnaissance faciale avec balayage numérique d'un visage">
         <h1 class="project-title">Reconnaissance Faciale</h1>
         <a class="git-link" href="https://github.com/hugo-kte/reconaissance-faciale">Voir le projet sur GitHub</a>
         <section id="pdf-viewer" class="pdf-viewer">

--- a/assets/coloria-thumb.svg
+++ b/assets/coloria-thumb.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360" role="img" aria-labelledby="title desc">
+  <title id="title">COLORIA project illustration</title>
+  <desc id="desc">Abstract gradient background with paint palette icon</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3a7bd5"/>
+      <stop offset="100%" stop-color="#00d2ff"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#1e3c72" flood-opacity="0.4"/>
+    </filter>
+  </defs>
+  <rect width="600" height="360" fill="url(#grad)" rx="28"/>
+  <g fill="none" stroke="rgba(255,255,255,0.35)" stroke-width="3">
+    <path d="M60 120c80-60 200-60 280 0"/>
+    <path d="M260 260c80 60 200 60 280 0"/>
+  </g>
+  <g transform="translate(180 90)" filter="url(#shadow)">
+    <path d="M120 180c66 0 120-54 120-120S186 0 120 0 0 54 0 120c0 46 42 60 60 60 12 0 18-6 30-6s18 6 30 6z" fill="#fff"/>
+    <circle cx="60" cy="80" r="16" fill="#1e90ff"/>
+    <circle cx="110" cy="46" r="14" fill="#ff8a00"/>
+    <circle cx="160" cy="92" r="16" fill="#ffd200"/>
+    <circle cx="118" cy="140" r="22" fill="#6c63ff"/>
+  </g>
+  <text x="300" y="320" fill="#ffffff" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="48" font-weight="600" text-anchor="middle" letter-spacing="4">COLORIA</text>
+</svg>

--- a/assets/facial-recognition-thumb.svg
+++ b/assets/facial-recognition-thumb.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360" role="img" aria-labelledby="title desc">
+  <title id="title">Facial recognition project illustration</title>
+  <desc id="desc">Stylised face outline with scanning grid</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f2027"/>
+      <stop offset="50%" stop-color="#203a43"/>
+      <stop offset="100%" stop-color="#2c5364"/>
+    </linearGradient>
+    <linearGradient id="scan" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#76b2fe" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#b69efe" stop-opacity="0.2"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+  <rect width="600" height="360" fill="url(#bg)" rx="28"/>
+  <g stroke="rgba(255,255,255,0.15)" stroke-width="2">
+    <path d="M120 60h360"/>
+    <path d="M120 120h360"/>
+    <path d="M120 180h360"/>
+    <path d="M120 240h360"/>
+    <path d="M120 300h360"/>
+  </g>
+  <rect x="150" y="40" width="300" height="280" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="6" rx="20"/>
+  <g transform="translate(220 90)" filter="url(#shadow)">
+    <path d="M80 20c-44 0-80 36-80 80v40c0 44 36 80 80 80s80-36 80-80v-40c0-44-36-80-80-80z" fill="none" stroke="#76b2fe" stroke-width="10"/>
+    <path d="M80 60c-24 0-44 20-44 44v12c0 24 20 44 44 44s44-20 44-44v-12c0-24-20-44-44-44z" fill="none" stroke="#b69efe" stroke-width="6"/>
+    <circle cx="58" cy="102" r="10" fill="#76b2fe"/>
+    <circle cx="102" cy="102" r="10" fill="#76b2fe"/>
+    <path d="M58 140c8 10 24 10 32 0" stroke="#76b2fe" stroke-width="6" stroke-linecap="round" fill="none"/>
+  </g>
+  <rect x="150" y="160" width="300" height="80" fill="url(#scan)" opacity="0.75"/>
+  <text x="300" y="330" fill="#ffffff" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="42" font-weight="600" text-anchor="middle" letter-spacing="5">FACIAL ID</text>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -181,6 +181,19 @@ footer {
     height: 100%;
 }
 
+/* Illustration des projets */
+.project-thumb {
+    width: 100%;
+    max-width: 520px;
+    height: 240px;
+    object-fit: cover;
+    border: 4px solid #1e90ff;
+    border-radius: 16px;
+    display: block;
+    margin: 20px auto;
+    box-shadow: 0 6px 18px rgba(30, 144, 255, 0.25);
+}
+
 /* Titre et lien GitHub */
 .project-title {
     text-align: center;


### PR DESCRIPTION
## Summary
- add dedicated thumbnails with descriptive alt text to each French and English project detail page
- create new SVG assets to illustrate the COLORIA and facial recognition projects
- style the shared thumbnail class with consistent sizing, border, and rounded corners

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8559546e483289ee6191ad369df9d