### PR TITLE
Adjust project grid spacing for responsive layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -254,6 +254,18 @@ footer {
     footer {
         font-size: 0.8rem;
     }
+
+    .grid {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+
+    .grid .project,
+    .grid .projectn {
+        box-sizing: border-box;
+        width: calc(100% - 24px);
+        margin: 0 12px 20px;
+    }
 }
 
 /* Ajustements pour les très grands écrans */
@@ -266,8 +278,8 @@ footer {
 /* Flexbox grid for projects */
 .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); /* Réduction de la largeur minimale */
-    gap: 15px; /* Réduction des espaces entre les items */
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); /* Largeur minimale légèrement augmentée pour les écrans plus larges */
+    gap: 20px; /* Espacement accru pour aérer les cartes */
 }
 
 /* Ensure images and videos are fluid */


### PR DESCRIPTION
## Summary
- increase the project grid min width and gap so cards breathe better on viewports wider than 480px
- collapse the project grid to a single column with lateral margins on phones to keep cards readable

## Testing
- Visual check: Playwright mobile/tablet for /Fr/projects.html and /En/projects.html


------
https://chatgpt.com/codex/tasks/task_e_68c8559cbd788328948a4a64ac1a8e19